### PR TITLE
Add JavaScript version of chart viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,20 @@
 
 Shipping insight display platform
 
-## Requirements
-- Python 3.12+
-- dash
-- pandas
+## JavaScript version
 
-Install dependencies:
+Open `index.html` in a web browser. The page loads `data.csv` and displays a
+line chart using Chart.js. Select a data series from the dropdown and use your
+mouse wheel or drag to zoom and pan along the time axis.
+
+## Python Dash version
+
+A legacy Dash implementation is kept in `app.py`. Install requirements with:
 ```bash
 pip install dash pandas
 ```
-
-## Running the application
-Ensure `data.csv` is present in the repository root. Then start the Dash app:
+Run the server:
 ```bash
 python app.py
 ```
-Open your browser at <http://127.0.0.1:8050> to interact with the chart. Select a data series from the dropdown and use the range slider or zoom controls to explore the time axis.
+Then browse to <http://127.0.0.1:8050>.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>ChartInsights Viewer</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@1.3.1/dist/chartjs-plugin-zoom.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.1/papaparse.min.js"></script>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        canvas { max-width: 100%; }
+    </style>
+</head>
+<body>
+    <h1>ChartInsights Viewer</h1>
+    <select id="series-select"></select>
+    <canvas id="chart"></canvas>
+    <script src="main.js"></script>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,66 @@
+document.addEventListener('DOMContentLoaded', () => {
+    fetch('data.csv')
+        .then(res => res.text())
+        .then(csvText => {
+            const parsed = Papa.parse(csvText, {header: true, dynamicTyping: true});
+            const rows = parsed.data.filter(r => r.date);
+            const seriesNames = parsed.meta.fields.filter(f => f !== 'date');
+
+            const select = document.getElementById('series-select');
+            seriesNames.forEach(name => {
+                const opt = document.createElement('option');
+                opt.value = name;
+                opt.textContent = name;
+                select.appendChild(opt);
+            });
+
+            let chart;
+            const ctx = document.getElementById('chart').getContext('2d');
+
+            function render(series) {
+                const dataset = rows.map(r => ({x: r.date, y: r[series]}));
+                if (chart) chart.destroy();
+                chart = new Chart(ctx, {
+                    type: 'line',
+                    data: {
+                        datasets: [{
+                            label: series,
+                            data: dataset,
+                            borderColor: 'steelblue',
+                            borderWidth: 2,
+                            fill: false,
+                            tension: 0.1,
+                            pointRadius: 0
+                        }]
+                    },
+                    options: {
+                        parsing: false,
+                        scales: {
+                            x: {
+                                type: 'time',
+                                time: {unit: 'day'},
+                                title: {display: true, text: 'Date'}
+                            },
+                            y: {
+                                title: {display: true, text: series}
+                            }
+                        },
+                        plugins: {
+                            zoom: {
+                                zoom: {
+                                    wheel: {enabled: true},
+                                    pinch: {enabled: true},
+                                    mode: 'x'
+                                },
+                                pan: {enabled: true, mode: 'x'}
+                            }
+                        }
+                    }
+                });
+            }
+
+            render(seriesNames[0]);
+            select.value = seriesNames[0];
+            select.addEventListener('change', () => render(select.value));
+        });
+});


### PR DESCRIPTION
## Summary
- create `index.html` and `main.js` to view `data.csv` in the browser
- enable zooming and panning with Chart.js and plugin
- update README with instructions for using the new HTML/JS viewer and legacy Dash version

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684175837054833088ff8bd813f51be4